### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @coderefinery/staff

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ tweet, please go by PRs unless making a quick reply.
 
 Tweet: <kbd>[Create new tweet](../../new/master/?filename=tweets/<your-path>.tweet)</kbd>
 
+This repository is protected by the `CODEOWNERS` file, which restricts
+who can merge.
 
 
 ## How-to


### PR DESCRIPTION
- https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#about-code-owners
- This should limit us to authorized tweeters (if the branch
  protection is set correctly), even if the organization default
  access is "write".
- Review: worth checking syntax + if semantics are as I expect.